### PR TITLE
Allow styling of selected reaction in OverlayReactionList

### DIFF
--- a/package/src/components/MessageOverlay/OverlayReactionList.tsx
+++ b/package/src/components/MessageOverlay/OverlayReactionList.tsx
@@ -60,9 +60,6 @@ const styles = StyleSheet.create({
     paddingVertical: 12,
     position: 'absolute',
   },
-  selectedIcon: {
-    position: 'absolute',
-  },
 });
 
 const reactionData: ReactionData[] = [
@@ -121,6 +118,7 @@ export const ReactionButton = <
       colors: { accent_blue, grey },
       overlay: {
         reactionsList: { reaction, reactionSize },
+        selectedReaction: { selectedReaction },
       },
     },
   } = useTheme();
@@ -218,7 +216,7 @@ export const ReactionButton = <
         style={[index !== numberOfReactions - 1 ? styles.notLastReaction : {}, reaction, iconStyle]}
       >
         <Icon height={reactionSize} pathFill={grey} width={reactionSize} />
-        <Animated.View style={[styles.selectedIcon, selectedStyle]}>
+        <Animated.View style={[selectedReaction, selectedStyle]}>
           <Icon height={reactionSize} pathFill={accent_blue} width={reactionSize} />
         </Animated.View>
       </Animated.View>

--- a/package/src/contexts/themeContext/utils/theme.ts
+++ b/package/src/contexts/themeContext/utils/theme.ts
@@ -608,6 +608,7 @@ export type Theme = {
       reactionList: ViewStyle;
       reactionListBorderRadius: number;
       reactionSize: number;
+      selectedReaction: ViewStyle;
     };
   };
   progressControl: {
@@ -1232,6 +1233,7 @@ export const defaultTheme: Theme = {
       reactionList: {},
       reactionListBorderRadius: 24,
       reactionSize: 24,
+      selectedReaction: { position: 'absolute' },
     },
   },
   progressControl: {


### PR DESCRIPTION
## 🎯 Goal

Allow customers to style the selected reaction in OverlayReactionList easily (previously all of OverlayReactionList had to be replaced)

In our case, we have emoji reactions (non-greyscale reactions) for which fillPath isn't sufficient to show them as "selected"

## 🛠 Implementation details

Add a theme entry for the selected reaction and apply it in OverlayReactionList.

## 🎨 UI Changes

No UI changes

## 🧪 Testing

Open the reaction overlay and check it's still functional and can be styled by changing the theme

## ☑️ Checklist

- [ ] I have signed the [Stream CLA](https://docs.google.com/forms/d/e/1FAIpQLScFKsKkAJI7mhCr7K9rEIOpqIDThrWxuvxnwUq2XkHyG154vQ/viewform) (required)
- [x] PR targets the `develop` branch
- [x] Documentation is updated
- [x] New code is tested in main example apps, including all possible scenarios
  - [x] SampleApp iOS and Android
  - [x] Expo iOS and Android


